### PR TITLE
Fix vertex addition drag tool

### DIFF
--- a/src/presentation/view-models/EditingViewModel.js
+++ b/src/presentation/view-models/EditingViewModel.js
@@ -645,6 +645,8 @@ export class EditingViewModel {
       // 地物全体の更新としても通知
       this._eventBus.publish('FeatureUpdated', { feature: result.updatedFeature });
 
+      return result.newVertex;
+
     } catch (error) {
       console.error('エッジへの頂点追加に失敗しました (EditingViewModel)', error);
       alert(`エッジへの頂点追加に失敗: ${error.message}`);

--- a/src/presentation/views/map/MapViewEventHandler.js
+++ b/src/presentation/views/map/MapViewEventHandler.js
@@ -132,6 +132,13 @@ export class MapViewEventHandler {
           const closestEdgeInfo = this._interactionLogic.findClosestEdge(worldPoint);
           if (closestEdgeInfo) {
             this._editingViewModel.addVertexToEdge(closestEdgeInfo)
+              .then(newVertex => {
+                if (newVertex) {
+                  const map = new Map([[newVertex.id, { x: newVertex.x, y: newVertex.y }]]);
+                  this._editingViewModel.startVerticesDrag(map);
+                  this._isDragging = true;
+                }
+              })
               .catch(error => {
                 console.error("[EventHandler] Error calling addVertexToEdge:", error);
                 alert(`線上への頂点追加に失敗しました: ${error.message}`);


### PR DESCRIPTION
## Summary
- allow dragging newly inserted vertices on edge
- expose added vertex from `addVertexToEdge`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e43e30fcc8332917242dede47f061