### PR TITLE
Implement style provider for editing

### DIFF
--- a/src/domain/services/GeometryService.js
+++ b/src/domain/services/GeometryService.js
@@ -97,6 +97,41 @@ export class GeometryService {
   }
 
   /**
+   * 2点間の大円コースを取得
+   * @param {number} lon1 - 点1の経度
+   * @param {number} lat1 - 点1の緯度
+   * @param {number} lon2 - 点2の経度
+   * @param {number} lat2 - 点2の緯度
+   * @param {number} segments - 分割数
+   * @returns {{x:number,y:number}[]} 大円上の点配列
+   */
+  calculateGreatCirclePath(lon1, lat1, lon2, lat2, segments = 32) {
+    const φ1 = this._toRadians(lat1);
+    const λ1 = this._toRadians(lon1);
+    const φ2 = this._toRadians(lat2);
+    const λ2 = this._toRadians(lon2);
+    const δ = 2 * Math.asin(Math.sqrt(
+      Math.sin((φ2 - φ1) / 2) ** 2 +
+      Math.cos(φ1) * Math.cos(φ2) * Math.sin((λ2 - λ1) / 2) ** 2
+    ));
+    if (δ === 0) return [{ x: lon1, y: lat1 }, { x: lon2, y: lat2 }];
+    const sinδ = Math.sin(δ);
+    const path = [];
+    for (let i = 0; i <= segments; i++) {
+      const f = i / segments;
+      const A = Math.sin((1 - f) * δ) / sinδ;
+      const B = Math.sin(f * δ) / sinδ;
+      const x = A * Math.cos(φ1) * Math.cos(λ1) + B * Math.cos(φ2) * Math.cos(λ2);
+      const y = A * Math.cos(φ1) * Math.sin(λ1) + B * Math.cos(φ2) * Math.sin(λ2);
+      const z = A * Math.sin(φ1) + B * Math.sin(φ2);
+      const φ = Math.atan2(z, Math.sqrt(x * x + y * y));
+      const λ = Math.atan2(y, x);
+      path.push({ x: this._toDegrees(λ), y: this._toDegrees(φ) });
+    }
+    return path;
+  }
+
+  /**
    * 度をラジアンに変換
    * @param {number} degrees - 度数
    * @returns {number} ラジアン
@@ -104,6 +139,16 @@ export class GeometryService {
    */
   _toRadians(degrees) {
     return degrees * Math.PI / 180;
+  }
+
+  /**
+   * ラジアンを度に変換
+   * @param {number} radians - ラジアン
+   * @returns {number} 度数
+   * @private
+   */
+  _toDegrees(radians) {
+    return radians * 180 / Math.PI;
   }
 
   /**

--- a/src/infrastructure/rendering/RenderStyleProvider.js
+++ b/src/infrastructure/rendering/RenderStyleProvider.js
@@ -7,7 +7,7 @@
 export function getPointStyle(property) {
   const categoryStyles = {
     city: {
-      radius: 5,
+      radius: 6,
       fill: "#ff0000",
       stroke: "#000000",
       strokeWidth: 1,
@@ -16,7 +16,7 @@ export function getPointStyle(property) {
       showLabel: true,
     },
     town: {
-      radius: 3,
+      radius: 4,
       fill: "#ff3333",
       stroke: "#000000",
       strokeWidth: 1,
@@ -25,7 +25,7 @@ export function getPointStyle(property) {
       showLabel: true,
     },
     battle: {
-      radius: 4,
+      radius: 5,
       fill: "#ff0000",
       stroke: "#000000",
       strokeWidth: 1,
@@ -34,7 +34,7 @@ export function getPointStyle(property) {
       showLabel: true,
     },
     ruin: {
-      radius: 4,
+      radius: 5,
       fill: "#996633",
       stroke: "#000000",
       strokeWidth: 1,
@@ -44,7 +44,7 @@ export function getPointStyle(property) {
     },
     // デフォルトスタイル
     default: {
-      radius: 4,
+      radius: 5,
       fill: "#3388ff",
       stroke: "#000000",
       strokeWidth: 1,
@@ -62,7 +62,7 @@ export function getLineStyle(property) {
   const categoryStyles = {
     road: {
       stroke: "#996633",
-      strokeWidth: 2,
+      strokeWidth: 3,
       strokeDasharray: "",
       textColor: "#000000",
       fontSize: 10,
@@ -70,7 +70,7 @@ export function getLineStyle(property) {
     },
     railway: {
       stroke: "#333333",
-      strokeWidth: 2,
+      strokeWidth: 3,
       strokeDasharray: "5,5",
       textColor: "#000000",
       fontSize: 10,
@@ -78,7 +78,7 @@ export function getLineStyle(property) {
     },
     river: {
       stroke: "#3388ff",
-      strokeWidth: 2,
+      strokeWidth: 3,
       strokeDasharray: "",
       textColor: "#000000",
       fontSize: 10,
@@ -86,7 +86,7 @@ export function getLineStyle(property) {
     },
     trade_route: {
       stroke: "#ff8800",
-      strokeWidth: 2,
+      strokeWidth: 3,
       strokeDasharray: "10,2",
       textColor: "#000000",
       fontSize: 10,
@@ -94,7 +94,7 @@ export function getLineStyle(property) {
     },
     border: {
       stroke: "#ff0000",
-      strokeWidth: 3,
+      strokeWidth: 4,
       strokeDasharray: "",
       textColor: "#000000",
       fontSize: 10,
@@ -103,7 +103,7 @@ export function getLineStyle(property) {
     // デフォルトスタイル
     default: {
       stroke: "#3388ff",
-      strokeWidth: 2,
+      strokeWidth: 3,
       strokeDasharray: "",
       textColor: "#000000",
       fontSize: 10,
@@ -120,8 +120,8 @@ export function getPolygonStyle(property) {
     kingdom: {
       fill: "#ff8888",
       stroke: "#ff0000",
-      strokeWidth: 2,
-      fillOpacity: 0.6,
+      strokeWidth: 3,
+      fillOpacity: 0.7,
       textColor: "#000000",
       fontSize: 14,
       showLabel: true,
@@ -129,8 +129,8 @@ export function getPolygonStyle(property) {
     empire: {
       fill: "#8888ff",
       stroke: "#0000ff",
-      strokeWidth: 2,
-      fillOpacity: 0.6,
+      strokeWidth: 3,
+      fillOpacity: 0.7,
       textColor: "#000000",
       fontSize: 16,
       showLabel: true,
@@ -138,8 +138,8 @@ export function getPolygonStyle(property) {
     province: {
       fill: "#88ff88",
       stroke: "#008800",
-      strokeWidth: 2,
-      fillOpacity: 0.6,
+      strokeWidth: 3,
+      fillOpacity: 0.7,
       textColor: "#000000",
       fontSize: 12,
       showLabel: true,
@@ -147,8 +147,8 @@ export function getPolygonStyle(property) {
     ocean: {
       fill: "#3388ff",
       stroke: "#3388ff",
-      strokeWidth: 1,
-      fillOpacity: 0.4,
+      strokeWidth: 2,
+      fillOpacity: 0.5,
       textColor: "#000000",
       fontSize: 14,
       showLabel: true,
@@ -156,8 +156,8 @@ export function getPolygonStyle(property) {
     lake: {
       fill: "#3388ff",
       stroke: "#3388ff",
-      strokeWidth: 1,
-      fillOpacity: 0.6,
+      strokeWidth: 2,
+      fillOpacity: 0.7,
       textColor: "#000000",
       fontSize: 12,
       showLabel: true,
@@ -166,8 +166,8 @@ export function getPolygonStyle(property) {
     default: {
       fill: "#ffcc88",
       stroke: "#ff8800",
-      strokeWidth: 2,
-      fillOpacity: 0.6,
+      strokeWidth: 3,
+      fillOpacity: 0.7,
       textColor: "#000000",
       fontSize: 12,
       showLabel: true,
@@ -179,24 +179,24 @@ export function getPolygonStyle(property) {
 }
 
 export const editingStyles = {
-  normalVertex: { radius: 4, fill: 'rgba(0, 150, 255, 0.5)', stroke: 'rgba(0, 100, 200, 0.7)', strokeWidth: 1 },
-  selectedOutline: { stroke: '#00ffff', strokeWidth: 4, fill: 'none', strokeDasharray: '4,4' },
-  selectedPointOutline: { radius: 8, stroke: '#00ffff', strokeWidth: 2, fill: 'none' },
-  selectedVertex: { radius: 6, fill: '#00ffff', stroke: '#0000ff', strokeWidth: 2 },
-  highlightOutline: { stroke: '#0088aa', strokeWidth: 2, fill: 'none', strokeDasharray: '2,2' },
-  dragVertex: { fill: '#ff00ff', radius: 7, stroke: '#ffffff', strokeWidth: 2 },
-  dragOutline: { stroke: '#ff00ff', strokeWidth: 2, fill: 'none', strokeDasharray: '3,3' },
-  addingPointPreview: { fill: '#ffffff', radius: 4, stroke: '#000000', strokeWidth: 1 },
-  addingToolPoint: { fill: '#ff0000', radius: 6, stroke: '#ffffff', strokeWidth: 2 },
-  linePreviewForLine: { stroke: '#0000ff', strokeWidth: 3, strokeDasharray: '5,5' },
-  linePreviewForPolygon: { stroke: '#00ff00', strokeWidth: 3, strokeDasharray: '5,5' },
-  linePreviewHole: { stroke: '#ff00ff', strokeWidth: 3, strokeDasharray: '5,5' },
-  linePreviewEnclave: { stroke: '#ff8800', strokeWidth: 3, strokeDasharray: '5,5' },
-  linePreviewPending: { stroke: '#aaaaaa', strokeWidth: 3, strokeDasharray: '5,5' },
-  measurePoint: { fill: '#ffff00', radius: 4, stroke: '#000000', strokeWidth: 1 },
-  measureLine: { stroke: '#ffff00', strokeWidth: 2, strokeDasharray: '5,5' },
+  normalVertex: { radius: 5, fill: 'rgba(0, 150, 255, 0.5)', stroke: 'rgba(0, 100, 200, 0.7)', strokeWidth: 1 },
+  selectedOutline: { stroke: '#00ffff', strokeWidth: 5, fill: 'none', strokeDasharray: '' },
+  selectedPointOutline: { radius: 9, stroke: '#00ffff', strokeWidth: 2, fill: 'none' },
+  selectedVertex: { radius: 7, fill: '#0080ff', stroke: '#0000ff', strokeWidth: 3 },
+  highlightOutline: { stroke: '#0088aa', strokeWidth: 3, fill: 'none', strokeDasharray: '4,2' },
+  dragVertex: { fill: '#ff00ff', radius: 8, stroke: '#ffffff', strokeWidth: 2 },
+  dragOutline: { stroke: '#ff00ff', strokeWidth: 3, fill: 'none', strokeDasharray: '3,3' },
+  addingPointPreview: { fill: '#ffffff', radius: 5, stroke: '#000000', strokeWidth: 1 },
+  addingToolPoint: { fill: '#ff0000', radius: 7, stroke: '#ffffff', strokeWidth: 2 },
+  linePreviewForLine: { stroke: '#0000ff', strokeWidth: 4, strokeDasharray: '5,5' },
+  linePreviewForPolygon: { stroke: '#00ff00', strokeWidth: 4, strokeDasharray: '5,5' },
+  linePreviewHole: { stroke: '#ff00ff', strokeWidth: 4, strokeDasharray: '5,5' },
+  linePreviewEnclave: { stroke: '#ff8800', strokeWidth: 4, strokeDasharray: '5,5' },
+  linePreviewPending: { stroke: '#aaaaaa', strokeWidth: 4, strokeDasharray: '5,5' },
+  measurePoint: { fill: '#ffff00', radius: 5, stroke: '#000000', strokeWidth: 1 },
+  measureLine: { stroke: '#ffff00', strokeWidth: 3, strokeDasharray: '' },
   greatCircleLine: { stroke: '#ff5500', strokeWidth: 1, strokeDasharray: '2,2' },
-  measureLabel: { fontSize: 10, textColor: '#000000', textAnchor: 'middle', dominantBaseline: 'hanging' },
-  measureSegmentLabel: { fontSize: 9, textColor: '#333300', textAnchor: 'middle', dominantBaseline: 'alphabetic' },
-  totalLabel: { fontSize: 10, textColor: '#000000', textAnchor: 'start', dominantBaseline: 'hanging' },
+  measureLabel: { fontSize: 11, textColor: '#000000', textAnchor: 'middle', dominantBaseline: 'hanging' },
+  measureSegmentLabel: { fontSize: 10, textColor: '#333300', textAnchor: 'middle', dominantBaseline: 'alphabetic' },
+  totalLabel: { fontSize: 11, textColor: '#000000', textAnchor: 'start', dominantBaseline: 'hanging' },
 };

--- a/src/infrastructure/rendering/RenderStyleProvider.js
+++ b/src/infrastructure/rendering/RenderStyleProvider.js
@@ -195,6 +195,7 @@ export const editingStyles = {
   linePreviewPending: { stroke: '#aaaaaa', strokeWidth: 3, strokeDasharray: '5,5' },
   measurePoint: { fill: '#ffff00', radius: 4, stroke: '#000000', strokeWidth: 1 },
   measureLine: { stroke: '#ffff00', strokeWidth: 2, strokeDasharray: '5,5' },
+  greatCircleLine: { stroke: '#ff5500', strokeWidth: 1, strokeDasharray: '2,2' },
   measureLabel: { fontSize: 10, textColor: '#000000', textAnchor: 'middle', dominantBaseline: 'hanging' },
   measureSegmentLabel: { fontSize: 9, textColor: '#333300', textAnchor: 'middle', dominantBaseline: 'alphabetic' },
   totalLabel: { fontSize: 10, textColor: '#000000', textAnchor: 'start', dominantBaseline: 'hanging' },

--- a/src/infrastructure/rendering/RenderStyleProvider.js
+++ b/src/infrastructure/rendering/RenderStyleProvider.js
@@ -177,3 +177,25 @@ export function getPolygonStyle(property) {
   const category = property.getAttribute("category", "default");
   return categoryStyles[category] || categoryStyles.default;
 }
+
+export const editingStyles = {
+  normalVertex: { radius: 4, fill: 'rgba(0, 150, 255, 0.5)', stroke: 'rgba(0, 100, 200, 0.7)', strokeWidth: 1 },
+  selectedOutline: { stroke: '#00ffff', strokeWidth: 4, fill: 'none', strokeDasharray: '4,4' },
+  selectedPointOutline: { radius: 8, stroke: '#00ffff', strokeWidth: 2, fill: 'none' },
+  selectedVertex: { radius: 6, fill: '#00ffff', stroke: '#0000ff', strokeWidth: 2 },
+  highlightOutline: { stroke: '#0088aa', strokeWidth: 2, fill: 'none', strokeDasharray: '2,2' },
+  dragVertex: { fill: '#ff00ff', radius: 7, stroke: '#ffffff', strokeWidth: 2 },
+  dragOutline: { stroke: '#ff00ff', strokeWidth: 2, fill: 'none', strokeDasharray: '3,3' },
+  addingPointPreview: { fill: '#ffffff', radius: 4, stroke: '#000000', strokeWidth: 1 },
+  addingToolPoint: { fill: '#ff0000', radius: 6, stroke: '#ffffff', strokeWidth: 2 },
+  linePreviewForLine: { stroke: '#0000ff', strokeWidth: 3, strokeDasharray: '5,5' },
+  linePreviewForPolygon: { stroke: '#00ff00', strokeWidth: 3, strokeDasharray: '5,5' },
+  linePreviewHole: { stroke: '#ff00ff', strokeWidth: 3, strokeDasharray: '5,5' },
+  linePreviewEnclave: { stroke: '#ff8800', strokeWidth: 3, strokeDasharray: '5,5' },
+  linePreviewPending: { stroke: '#aaaaaa', strokeWidth: 3, strokeDasharray: '5,5' },
+  measurePoint: { fill: '#ffff00', radius: 4, stroke: '#000000', strokeWidth: 1 },
+  measureLine: { stroke: '#ffff00', strokeWidth: 2, strokeDasharray: '5,5' },
+  measureLabel: { fontSize: 10, textColor: '#000000', textAnchor: 'middle', dominantBaseline: 'hanging' },
+  measureSegmentLabel: { fontSize: 9, textColor: '#333300', textAnchor: 'middle', dominantBaseline: 'alphabetic' },
+  totalLabel: { fontSize: 10, textColor: '#000000', textAnchor: 'start', dominantBaseline: 'hanging' },
+};

--- a/src/presentation/view-models/MapViewModel.js
+++ b/src/presentation/view-models/MapViewModel.js
@@ -679,6 +679,23 @@ export class MapViewModel {
   }
 
   /**
+   * 2点間の大円コースを取得
+   * @param {{x:number,y:number}} point1
+   * @param {{x:number,y:number}} point2
+   * @param {number} segments
+   * @returns {{x:number,y:number}[]} 点列
+   */
+  calculateGreatCirclePath(point1, point2, segments = 32) {
+    return this._geometryService.calculateGreatCirclePath(
+      point1.x,
+      point1.y,
+      point2.x,
+      point2.y,
+      segments
+    );
+  }
+
+  /**
    * 多角形の面積を計算
    * @param {string[]} vertexIds - 頂点IDの配列 (特定のリングの頂点IDを渡す想定)
    * @param {number} equatorLength - 赤道長（km）

--- a/src/presentation/views/map/MapViewRendererHelper.js
+++ b/src/presentation/views/map/MapViewRendererHelper.js
@@ -3,6 +3,7 @@
 import { Point as DomainPoint } from '../../../domain/entities/Point.js';
 import { Line as DomainLine } from '../../../domain/entities/Line.js';
 import { Polygon as DomainPolygon } from '../../../domain/entities/Polygon.js';
+import { editingStyles } from '../../../infrastructure/rendering/RenderStyleProvider.js';
 
 /**
  * MapView における描画補助（選択、プレビュー、測定など）を担当
@@ -57,7 +58,7 @@ export class MapViewRendererHelper {
     const finalOffsets = [0, -worldWidth, worldWidth];
 
     // 通常頂点マーカーのスタイル
-    const normalVertexStyle = { radius: 3, fill: 'rgba(0, 150, 255, 0.5)', stroke: 'rgba(0, 100, 200, 0.7)', strokeWidth: 1, pointerEvents: 'none' };
+    const normalVertexStyle = editingStyles.normalVertex;
 
     // ドラッグ中でない頂点の元の位置を取得する関数
     const getOriginalVertexPosIfNeitherSelectedNorDragged = (vertexId) => {
@@ -70,12 +71,12 @@ export class MapViewRendererHelper {
     if (selectedFeatureId) {
         const feature = this._viewModel.getFeatures().find(f => f.id === selectedFeatureId);
         if (feature && feature.existsAt(currentTime)) {
-            const style = { stroke: '#00ffff', strokeWidth: 4, fill: 'none', strokeDasharray: '4,4' };
+            const style = editingStyles.selectedOutline;
             for (const offsetX of finalOffsets) {
                 if (feature instanceof DomainPoint) {
                     const vData = verticesMap.get(feature.vertexId); // Points always have original data for this
                     if (vData && !selectedVertexIds.has(vData.id) && !draggingVerticesInfo.has(vData.id)) { // Only draw if not specially handled
-                        const elem = this._renderer.drawPoint(vData.x + offsetX, vData.y, { radius: 8, stroke: '#00ffff', strokeWidth: 2, fill: 'none', 'stroke-dasharray': '2,2'}, viewport);
+                        const elem = this._renderer.drawPoint(vData.x + offsetX, vData.y, editingStyles.selectedPointOutline, viewport);
                         if (elem) this._selectionElements.push(elem);
                     }
                 } else if (feature instanceof DomainLine) {
@@ -124,7 +125,7 @@ export class MapViewRendererHelper {
     if (highlightedFeatureId && highlightedFeatureId !== selectedFeatureId) {
         const feature = this._viewModel.getFeatures().find(f => f.id === highlightedFeatureId);
         if (feature && feature.existsAt(currentTime)) {
-            const style = { stroke: '#0088aa', strokeWidth: 2, fill: 'none', strokeDasharray: '2,2' };
+            const style = editingStyles.highlightOutline;
             for (const offsetX of finalOffsets) {
                 if (feature instanceof DomainLine) {
                      const linePoints = feature.vertexIds.map(id => {
@@ -158,7 +159,7 @@ export class MapViewRendererHelper {
         if (vData) {
             for (const offsetX of finalOffsets) { // オフセットループ
                 // オフセットを適用したワールド座標で描画
-                const elem = this._renderer.drawPoint(vData.x + offsetX, vData.y, { radius: 6, fill: '#00ffff', stroke: '#0000ff', strokeWidth: 2 }, viewport);
+                const elem = this._renderer.drawPoint(vData.x + offsetX, vData.y, editingStyles.selectedVertex, viewport);
                 if (elem) this._selectionElements.push(elem);
             }
         }
@@ -190,7 +191,7 @@ export class MapViewRendererHelper {
     for (const [vertexId, info] of draggingVerticesInfo.entries()) {
         for (const offsetX of finalOffsets) { // オフセットループ
             // オフセットを適用したワールド座標で描画
-            const marker = this._renderer.drawPoint(info.currentPosition.x + offsetX, info.currentPosition.y, { fill: '#ff00ff', radius: 7, stroke: '#ffffff', strokeWidth: 2 }, viewport);
+            const marker = this._renderer.drawPoint(info.currentPosition.x + offsetX, info.currentPosition.y, editingStyles.dragVertex, viewport);
             if (marker) this._dragPreviewElements.push(marker);
         }
     }
@@ -214,7 +215,7 @@ export class MapViewRendererHelper {
     };
 
     affectedFeatures.forEach(feature => {
-        const style = { stroke: '#ff00ff', strokeWidth: 2, fill: 'none', strokeDasharray: '3,3' };
+        const style = editingStyles.dragOutline;
         for (const offsetX of finalOffsets) { // オフセットループ
             if (feature instanceof DomainLine) {
                 const lineVertices = feature.vertexIds.map(id => getVertexPosWithOffset(id, offsetX)).filter(Boolean);
@@ -259,16 +260,16 @@ export class MapViewRendererHelper {
     if (addingPoints.length === 0) return;
     const viewport = this._viewportManager.getViewport();
 
-    const pointStyle = { fill: '#ffffff', radius: 4, stroke: '#000000', strokeWidth: 1 };
+    const pointStyle = editingStyles.addingPointPreview;
     let lineStyle = {};
     if (mode === 'add') {
-        lineStyle = tool === 'line' ? { stroke: '#0000ff', strokeWidth: 3, strokeDasharray: '5,5' }
-                  : tool === 'polygon' ? { stroke: '#00ff00', strokeWidth: 3, strokeDasharray: '5,5' }
+        lineStyle = tool === 'line' ? editingStyles.linePreviewForLine
+                  : tool === 'polygon' ? editingStyles.linePreviewForPolygon
                   : {};
     } else if (mode === 'edit' && tool === 'add-hole') {
-        lineStyle = subMode === 'hole' ? { stroke: '#ff00ff', strokeWidth: 3, strokeDasharray: '5,5' }
-                  : subMode === 'enclave' ? { stroke: '#ff8800', strokeWidth: 3, strokeDasharray: '5,5' }
-                  : { stroke: '#aaaaaa', strokeWidth: 3, strokeDasharray: '5,5' }; // サブモード未決定時
+        lineStyle = subMode === 'hole' ? editingStyles.linePreviewHole
+                  : subMode === 'enclave' ? editingStyles.linePreviewEnclave
+                  : editingStyles.linePreviewPending; // サブモード未決定時
     }
     
     // 追加中のプレビューは、通常ワールドの端をまたいで作成することは想定しづらいため、
@@ -278,7 +279,7 @@ export class MapViewRendererHelper {
 
     if (tool === 'point') {
         if (addingPoints.length === 1) {
-            const elem = this._renderer.drawPoint(addingPoints[0].x, addingPoints[0].y, { fill: '#ff0000', radius: 6, stroke: '#ffffff', strokeWidth: 2 }, viewport);
+            const elem = this._renderer.drawPoint(addingPoints[0].x, addingPoints[0].y, editingStyles.addingToolPoint, viewport);
             if (elem) this._addingElements.push(elem);
         }
     } else if (tool === 'line' || tool === 'polygon' || tool === 'add-hole') {
@@ -319,14 +320,14 @@ export class MapViewRendererHelper {
     // オフセット描画は行わない。
 
     measurePoints.forEach((point, index) => {
-        const pointElem = this._renderer.drawPoint(point.x, point.y, { fill: '#ffff00', radius: 4, stroke: '#000000', strokeWidth: 1 }, viewport);
+        const pointElem = this._renderer.drawPoint(point.x, point.y, editingStyles.measurePoint, viewport);
         if (pointElem) this._measureElements.push(pointElem);
-        const labelElem = this._renderer.drawText(point.x, point.y + 10 / viewport.zoom, String.fromCharCode(65 + index), { fontSize: 10, textColor: '#000000', textAnchor: 'middle', dominantBaseline: 'hanging'}, viewport);
+        const labelElem = this._renderer.drawText(point.x, point.y + 10 / viewport.zoom, String.fromCharCode(65 + index), editingStyles.measureLabel, viewport);
         if(labelElem) this._measureElements.push(labelElem);
     });
 
     if (measurePoints.length >= 2) {
-        const lineElem = this._renderer.drawLine(measurePoints, { stroke: '#ffff00', strokeWidth: 2, strokeDasharray: '5,5' }, viewport);
+        const lineElem = this._renderer.drawLine(measurePoints, editingStyles.measureLine, viewport);
         if (lineElem) this._measureElements.push(lineElem);
 
         // 赤道長を MapViewModel から取得
@@ -342,15 +343,15 @@ export class MapViewRendererHelper {
             totalGreatCircle += distance.greatCircle;
             const midX = (p1.x + p2.x) / 2;
             const midY = (p1.y + p2.y) / 2;
-            const segmentLabelElem = this._renderer.drawText(midX, midY - 10 / viewport.zoom, `${distance.linear.toFixed(1)}km`, { fontSize: 9, textColor: '#333300', textAnchor: 'middle', dominantBaseline: 'alphabetic'}, viewport);
+            const segmentLabelElem = this._renderer.drawText(midX, midY - 10 / viewport.zoom, `${distance.linear.toFixed(1)}km`, editingStyles.measureSegmentLabel, viewport);
             if(segmentLabelElem) this._measureElements.push(segmentLabelElem);
         }
 
         const lastPoint = measurePoints[measurePoints.length - 1];
         const textYOffset = 15 / viewport.zoom;
-        const totalLinearElem = this._renderer.drawText(lastPoint.x + 10 / viewport.zoom, lastPoint.y + textYOffset * 2, `直線計: ${totalLinear.toFixed(1)} km`, { fontSize: 10, textColor: '#000000', textAnchor: 'start', dominantBaseline: 'hanging'}, viewport);
+        const totalLinearElem = this._renderer.drawText(lastPoint.x + 10 / viewport.zoom, lastPoint.y + textYOffset * 2, `直線計: ${totalLinear.toFixed(1)} km`, editingStyles.totalLabel, viewport);
         if(totalLinearElem) this._measureElements.push(totalLinearElem);
-        const totalGreatCircleElem = this._renderer.drawText(lastPoint.x + 10 / viewport.zoom, lastPoint.y + textYOffset, `大円計: ${totalGreatCircle.toFixed(1)} km`, { fontSize: 10, textColor: '#000000', textAnchor: 'start', dominantBaseline: 'hanging'}, viewport);
+        const totalGreatCircleElem = this._renderer.drawText(lastPoint.x + 10 / viewport.zoom, lastPoint.y + textYOffset, `大円計: ${totalGreatCircle.toFixed(1)} km`, editingStyles.totalLabel, viewport);
         if(totalGreatCircleElem) this._measureElements.push(totalGreatCircleElem);
     }
     this._measureElements.forEach(el => el.classList.add('temp-drawing', 'measure-element'));

--- a/src/presentation/views/map/MapViewRendererHelper.js
+++ b/src/presentation/views/map/MapViewRendererHelper.js
@@ -330,6 +330,18 @@ export class MapViewRendererHelper {
         const lineElem = this._renderer.drawLine(measurePoints, editingStyles.measureLine, viewport);
         if (lineElem) this._measureElements.push(lineElem);
 
+        // 大圏コースを追加描画
+        const gcPoints = [];
+        for (let i = 1; i < measurePoints.length; i++) {
+            const segment = this._viewModel.calculateGreatCirclePath(measurePoints[i - 1], measurePoints[i]);
+            if (gcPoints.length > 0) segment.shift();
+            gcPoints.push(...segment);
+        }
+        if (gcPoints.length >= 2) {
+            const gcElem = this._renderer.drawLine(gcPoints, editingStyles.greatCircleLine, viewport);
+            if (gcElem) this._measureElements.push(gcElem);
+        }
+
         // 赤道長を MapViewModel から取得
         const equatorLength = this._viewModel.getEquatorLength(); 
         let totalLinear = 0;


### PR DESCRIPTION
## Summary
- centralize editing styles in RenderStyleProvider
- use the shared styles in MapViewRendererHelper

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ecc1c54988332b882c76a98e4b45f