### PR TITLE
Fix add-hole tool persistence

### DIFF
--- a/src/presentation/view-models/EditingViewModel.js
+++ b/src/presentation/view-models/EditingViewModel.js
@@ -274,7 +274,6 @@ export class EditingViewModel {
     if (this._mode !== 'edit' || this._tool !== 'add-hole' || this._addingSubMode !== 'hole' || !this._targetPolygon || !this._targetRingIdForHole || this._addingPoints.length < 3) {
         console.error('穴の追加確定の条件を満たしていません。');
         this._clearAddingState();
-        this.setTool('select'); // ツールを戻す
         return null;
     }
 
@@ -305,13 +304,11 @@ export class EditingViewModel {
 
         this._eventBus.publish('FeatureUpdated', { feature: updatedPolygon });
         this._clearAddingState();
-        this.setTool('select');
         return updatedPolygon;
     } catch (error) {
         console.error('穴の追加確定に失敗しました', error);
         alert(`穴の追加に失敗しました: ${error.message}`);
         this._clearAddingState();
-        this.setTool('select');
         return null;
     }
   }
@@ -324,7 +321,6 @@ export class EditingViewModel {
     if (this._mode !== 'edit' || this._tool !== 'add-hole' || this._addingSubMode !== 'enclave' || !this._targetPolygon || this._addingPoints.length < 3) {
         console.error('飛び地の追加確定の条件を満たしていません。');
         this._clearAddingState();
-        this.setTool('select');
         return null;
     }
 
@@ -351,13 +347,11 @@ export class EditingViewModel {
         
         this._eventBus.publish('FeatureUpdated', { feature: updatedPolygon });
         this._clearAddingState();
-        this.setTool('select');
         return updatedPolygon;
     } catch (error) {
         console.error('飛び地の追加確定に失敗しました', error);
         alert(`飛び地の追加に失敗しました: ${error.message}`);
         this._clearAddingState();
-        this.setTool('select');
         return null;
     }
   }

--- a/src/presentation/views/MapView.js
+++ b/src/presentation/views/MapView.js
@@ -163,7 +163,6 @@ export class MapView {
       case 'mode': // 編集モード変更
       case 'tool': // 選択ツール変更
         this._updateActionButtonsVisibility(); // ボタン表示更新
-        this._viewModel.clearSelection(); // モード変更時は選択解除
         if (this._editingViewModel.getDraggingVerticesInfo().size > 0) {
              this._editingViewModel._resetDraggingState(); // ドラッグ状態リセット
         }


### PR DESCRIPTION
## Summary
- keep selection when switching editing tools
- avoid reverting to select tool after adding holes or enclaves

## Testing
- `npm run build` *(fails: webpack not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685146f6899883328c60681178535093