### PR TITLE
Fix measurement tool persistence

### DIFF
--- a/src/presentation/views/MapView.js
+++ b/src/presentation/views/MapView.js
@@ -268,9 +268,7 @@ export class MapView {
   setMeasuringDistance(enabled) {
     if (this._isMeasuringDistance !== enabled) {
         this._isMeasuringDistance = enabled;
-        if (!enabled) {
-            this.clearMeasurements(); // モード解除時に測定結果をクリア
-        } else {
+        if (enabled) {
             // 測定開始時に編集モードなどを解除
             this._editingViewModel.setMode('view');
             this._viewModel.clearSelection();

--- a/src/presentation/views/map/MapViewEventHandler.js
+++ b/src/presentation/views/map/MapViewEventHandler.js
@@ -383,7 +383,6 @@ export class MapViewEventHandler {
      }
      // 距離測定中に右クリックでキャンセル
      else if (this._mapView.isMeasuringDistance()) {
-         this._mapView.clearMeasurements();
          this._mapView.setMeasuringDistance(false);
          console.log("Measurement cancelled by right-click.");
      }
@@ -452,7 +451,6 @@ export class MapViewEventHandler {
          console.log("Selection cleared by ESC.");
        } else if (this._mapView.isMeasuringDistance()) {
            // 距離測定中にEsc -> キャンセル
-           this._mapView.clearMeasurements();
            this._mapView.setMeasuringDistance(false);
            console.log("Measurement cancelled by ESC.");
        } else {

--- a/src/presentation/views/map/MapViewRendererHelper.js
+++ b/src/presentation/views/map/MapViewRendererHelper.js
@@ -313,7 +313,7 @@ export class MapViewRendererHelper {
   /** 距離測定を描画 */
   renderDistanceMeasurement(measurePoints, isMeasuring) {
     this.clearMeasureElements();
-    if (!isMeasuring || measurePoints.length === 0) return;
+    if (measurePoints.length === 0) return;
 
     const viewport = this._viewportManager.getViewport();
     // 距離測定のプレビューも、通常ワールドの端をまたいで行うことは稀なので、


### PR DESCRIPTION
## Summary
- keep measurement lines after exiting the measuring mode
- stop clearing measurements on right-click or ESC
- always render stored measurements

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517d635fe4833293a0dab1998ed36c