### PR TITLE
Fix grid display after reload

### DIFF
--- a/src/presentation/views/MapView.js
+++ b/src/presentation/views/MapView.js
@@ -253,6 +253,8 @@ export class MapView {
         // resize -> _onViewportChanged -> _render の流れで再描画されるため、ここでの _render() 呼び出しは不要
     } else {
         console.warn("MapView: Invalid container dimensions on resize.", { width, height });
+        // リロード直後は要素サイズが取得できない場合があるため再試行する
+        requestAnimationFrame(() => this._handleResize());
     }
   }
 


### PR DESCRIPTION
## Summary
- retry resize when the map container reports zero dimensions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517d620288833296c191a3a4e7150e