### PR TITLE
Fix map viewport initialization

### DIFF
--- a/src/presentation/views/MapView.js
+++ b/src/presentation/views/MapView.js
@@ -253,6 +253,8 @@ export class MapView {
         // resize -> _onViewportChanged -> _render の流れで再描画されるため、ここでの _render() 呼び出しは不要
     } else {
         console.warn("MapView: Invalid container dimensions on resize.", { width, height });
+        // リサイズ値が取得できない場合は少し待って再試行
+        setTimeout(() => this._handleResize(), 50);
     }
   }
 


### PR DESCRIPTION
## Summary
- retry resize when map container size cannot be determined on first attempt

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851806e12c88332ba551a14755f15ed