### PR TITLE
Fix vertex highlight issue during drag

### DIFF
--- a/src/presentation/views/map/MapViewRendererHelper.js
+++ b/src/presentation/views/map/MapViewRendererHelper.js
@@ -150,6 +150,30 @@ export class MapViewRendererHelper {
                         });
                      }
                 }
+
+                if (selectedVertexIds.size > 0 || draggingVerticesInfo.size > 0) {
+                    if (feature instanceof DomainLine) {
+                        feature.vertexIds.forEach(id => {
+                            const vData = getOriginalVertexPosIfNeitherSelectedNorDragged(id);
+                            if (vData) {
+                                const marker = this._renderer.drawPoint(vData.x + offsetX, vData.y, normalVertexStyle, viewport);
+                                if (marker) this._selectionElements.push(marker);
+                            }
+                        });
+                    } else if (feature instanceof DomainPolygon) {
+                        if (feature.rings && Array.isArray(feature.rings)) {
+                            feature.rings.forEach(ring => {
+                                ring.vertexIds.forEach(id => {
+                                    const vData = getOriginalVertexPosIfNeitherSelectedNorDragged(id);
+                                    if (vData) {
+                                        const marker = this._renderer.drawPoint(vData.x + offsetX, vData.y, normalVertexStyle, viewport);
+                                        if (marker) this._selectionElements.push(marker);
+                                    }
+                                });
+                            });
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- keep vertex markers of highlighted feature visible while dragging vertices

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851806c62588332b92b559d50b1cc02