### PR TITLE
Fix map position after reload

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -185,7 +185,11 @@ class TimeMapApp {
       // レンダラーに背景地図を設定
       const renderer = this._di.get('renderer');
       renderer.loadBackgroundMap(svgContent);
-      
+
+      // 背景地図読み込み後に再描画
+      const mapView = this._di.get('mapView');
+      mapView.refresh();
+
       console.log('背景地図を読み込みました');
     } catch (error) {
       console.error('背景地図の読み込みに失敗しました', error);

--- a/src/presentation/views/MapView.js
+++ b/src/presentation/views/MapView.js
@@ -38,6 +38,7 @@ export class MapView {
     this._mapElement = null;
     this._mapOverlay = null;
     this._actionButtonsContainer = null;
+    this._resizeObserver = null;
 
     // 状態
     this._isMeasuringDistance = false;
@@ -110,6 +111,14 @@ export class MapView {
 
     // イベントリスナー設定 (EventHandlerに委譲)
     this._eventHandler.setupEventListeners();
+
+    // コンテナサイズの変化を監視
+    if (typeof ResizeObserver !== 'undefined') {
+        this._resizeObserver = new ResizeObserver(() => {
+            this._handleResize();
+        });
+        this._resizeObserver.observe(this._container);
+    }
 
     // ウィンドウリサイズイベントの設定 (MapView自身で処理)
     window.addEventListener('resize', this._handleResize.bind(this));

--- a/src/presentation/views/MapView.js
+++ b/src/presentation/views/MapView.js
@@ -300,6 +300,11 @@ export class MapView {
     // this._render(); // 描画更新は不要な場合もあるが、念のため呼ぶ
   }
 
+  /** 強制的に再描画 */
+  refresh() {
+    this._render();
+  }
+
   // --- Private Helper Methods (主にEventHandlerから呼ばれる、または内部で使用) ---
 
   /** アクションボタンを作成 */


### PR DESCRIPTION
## Summary
- handle container resize with `ResizeObserver` so map loads correctly

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ad27f3d48332900ad523a5e3050d